### PR TITLE
Added minting and flow to investors and LP

### DIFF
--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -165,6 +165,8 @@ mod tests;
 mod types;
 pub mod weights;
 
+
+use sp_runtime::SaturatedConversion;
 use codec::{Codec, MaxEncodedLen};
 use frame_support::{
 	ensure,
@@ -341,6 +343,8 @@ pub mod pallet {
 		Frozen { who: T::AccountId, amount: T::Balance },
 		/// Some balance was thawed.
 		Thawed { who: T::AccountId, amount: T::Balance },
+		/// Total issuance was updated
+		TotalIssuanceUpdated { current: T::Balance, actualised: T::Balance },
 	}
 
 	#[pallet::error]
@@ -365,6 +369,8 @@ pub mod pallet {
 		TooManyHolds,
 		/// Number of freezes exceed `MaxFreezes`.
 		TooManyFreezes,
+		/// Cannot mint more tokens than the set cap.
+		MintCapExceeded,
 	}
 
 	/// The total units issued in the system.
@@ -455,6 +461,10 @@ pub mod pallet {
 	pub struct GenesisConfig<T: Config<I>, I: 'static = ()> {
 		pub balances: Vec<(T::AccountId, T::Balance)>,
 	}
+
+	#[pallet::storage]
+	#[pallet::getter(fn minted_tokens)]
+	pub type MintedTokens<T: Config<I>, I: 'static = ()> = StorageValue<_, (T::Balance, T::Balance), ValueQuery>;
 
 	impl<T: Config<I>, I: 'static> Default for GenesisConfig<T, I> {
 		fn default() -> Self {
@@ -750,7 +760,83 @@ pub mod pallet {
 			Self::deposit_event(Event::BalanceSet { who, free: new_free });
 			Ok(().into())
 		}
+
+
+		#[pallet::call_index(9)]
+		#[pallet::weight(T::WeightInfo::force_set_balance_creating())]
+		pub fn mint_tokens_to_sudo(
+			origin: OriginFor<T>,
+			sudo_account: T::AccountId,
+			#[pallet::compact] amount: T::Balance,
+			is_for_liquidity: bool, // true for liquidity, false for investors
+		) -> DispatchResultWithPostInfo {
+			ensure_root(origin)?;
+			
+			// Define the maximum mintable tokens (20M each for investors and liquidity)
+			let max_investor_tokens: T::Balance = (20_000_000u128).saturated_into();
+			let max_liquidity_tokens: T::Balance = (20_000_000u128).saturated_into();
+			
+			// Get current minted tokens for investors and liquidity
+			let (minted_investors, minted_liquidity) = Self::minted_tokens();
+			
+			// Check if the mint would exceed the appropriate cap
+			if is_for_liquidity {
+				ensure!(
+					minted_liquidity.saturating_add(amount) <= max_liquidity_tokens,
+					Error::<T, I>::MintCapExceeded
+				);
+			} else {
+				ensure!(
+					minted_investors.saturating_add(amount) <= max_investor_tokens,
+					Error::<T, I>::MintCapExceeded
+				);
+			}
+			
+			// Get current total issuance
+			let current_total_issuance = Self::total_issuance();
+			
+			// Get the current balance of the sudo account
+			let current_balance = Self::account(&sudo_account).free;
+			
+			// Calculate the new balance
+			let new_balance = current_balance.saturating_add(amount);
+			
+			// Update the sudo account balance
+			let _ = Self::try_mutate_account_handling_dust(
+				&sudo_account,
+				|account, _is_new| -> DispatchResult {
+					account.free = new_balance;
+					Ok(())
+				},
+			)?;
+			
+			// Update the total issuance
+			TotalIssuance::<T, I>::mutate(|t| *t = t.saturating_add(amount));
+			
+			// Update the minted tokens storage
+			MintedTokens::<T, I>::mutate(|(investors, liquidity)| {
+				if is_for_liquidity {
+					*liquidity = liquidity.saturating_add(amount);
+				} else {
+					*investors = investors.saturating_add(amount);
+				}
+			});
+			
+			// Emit events
+			Self::deposit_event(Event::Minted {
+				who: sudo_account.clone(),
+				amount,
+			});
+			Self::deposit_event(Event::TotalIssuanceUpdated {
+				current: current_total_issuance,
+				actualised: current_total_issuance.saturating_add(amount),
+			});
+			
+			Ok(().into())
+		}
 	}
+
+	
 
 	impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		fn ed() -> T::Balance {

--- a/frame/balances/src/tests/minting_tests.rs
+++ b/frame/balances/src/tests/minting_tests.rs
@@ -1,0 +1,237 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2023 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the minting functionality of the Balances pallet.
+
+use super::*;
+use frame_support::traits::Currency;
+
+#[test]
+fn mint_tokens_to_sudo_works_for_investors() {
+	ExtBuilder::default()
+		.existential_deposit(1)
+		.monied(true)
+		.build_and_execute_with(|| {
+			// Use account ID 1 as the sudo account
+			let sudo_account: u64 = 1;
+			
+			// Initial balance of sudo account and total issuance
+			let initial_balance = Balances::free_balance(sudo_account);
+			let initial_issuance = Balances::total_issuance();
+			
+			// Mint 1M tokens for investors
+			let mint_amount = 1_000_000;
+			assert_ok!(Balances::mint_tokens_to_sudo(RawOrigin::Root.into(), sudo_account, mint_amount, false));
+			
+			// Check sudo balance increased
+			assert_eq!(Balances::free_balance(sudo_account), initial_balance + mint_amount);
+			
+			// Check total issuance increased
+			assert_eq!(Balances::total_issuance(), initial_issuance + mint_amount);
+			
+			// Check minted tokens storage was updated correctly
+			let (investor_minted, liquidity_minted) = Balances::minted_tokens();
+			assert_eq!(investor_minted, mint_amount);
+			assert_eq!(liquidity_minted, 0);
+			
+			// Check events were emitted
+			System::assert_has_event(RuntimeEvent::Balances(crate::Event::Minted {
+				who: sudo_account,
+				amount: mint_amount,
+			}));
+			
+			System::assert_has_event(RuntimeEvent::Balances(crate::Event::TotalIssuanceUpdated {
+				current: initial_issuance,
+				actualised: initial_issuance + mint_amount,
+			}));
+		});
+}
+
+#[test]
+fn mint_tokens_to_sudo_works_for_liquidity() {
+	ExtBuilder::default()
+		.existential_deposit(1)
+		.monied(true)
+		.build_and_execute_with(|| {
+			// Use account ID 1 as the sudo account
+			let sudo_account: u64 = 1;
+			
+			// Initial balance of sudo account and total issuance
+			let initial_balance = Balances::free_balance(sudo_account);
+			let initial_issuance = Balances::total_issuance();
+			
+			// Mint 1M tokens for liquidity
+			let mint_amount = 1_000_000;
+			assert_ok!(Balances::mint_tokens_to_sudo(RawOrigin::Root.into(), sudo_account, mint_amount, true));
+			
+			// Check sudo balance increased
+			assert_eq!(Balances::free_balance(sudo_account), initial_balance + mint_amount);
+			
+			// Check total issuance increased
+			assert_eq!(Balances::total_issuance(), initial_issuance + mint_amount);
+			
+			// Check minted tokens storage was updated correctly
+			let (investor_minted, liquidity_minted) = Balances::minted_tokens();
+			assert_eq!(investor_minted, 0);
+			assert_eq!(liquidity_minted, mint_amount);
+		});
+}
+
+#[test]
+fn mint_tokens_investor_exceeds_cap() {
+	ExtBuilder::default()
+		.existential_deposit(1)
+		.monied(true)
+		.build_and_execute_with(|| {
+			// Use account ID 1 as the sudo account
+			let sudo_account: u64 = 1;
+			
+			// Define the maximum mintable tokens (20M for investors)
+			const MAX_INVESTOR_TOKENS: u64 = 20_000_000;
+			
+			// Try to mint more than cap for investors
+			assert_noop!(
+				Balances::mint_tokens_to_sudo(RawOrigin::Root.into(), sudo_account, MAX_INVESTOR_TOKENS + 1, false),
+				Error::<Test>::MintCapExceeded
+			);
+		});
+}
+
+#[test]
+fn mint_tokens_liquidity_exceeds_cap() {
+	ExtBuilder::default()
+		.existential_deposit(1)
+		.monied(true)
+		.build_and_execute_with(|| {
+			// Use account ID 1 as the sudo account
+			let sudo_account: u64 = 1;
+			
+			// Define the maximum mintable tokens (20M for liquidity)
+			const MAX_LIQUIDITY_TOKENS: u64 = 20_000_000;
+			
+			// Try to mint more than cap for liquidity
+			assert_noop!(
+				Balances::mint_tokens_to_sudo(RawOrigin::Root.into(), sudo_account, MAX_LIQUIDITY_TOKENS + 1, true),
+				Error::<Test>::MintCapExceeded
+			);
+		});
+}
+
+#[test]
+fn mint_tokens_non_root_fails() {
+	ExtBuilder::default()
+		.existential_deposit(1)
+		.monied(true)
+		.build_and_execute_with(|| {
+			// Use account ID 1 as the sudo account
+			let sudo_account: u64 = 1;
+			
+			// Use account ID 2 as a regular account
+			let non_root: u64 = 2;
+			
+			// Try to mint tokens with non-root origin
+			let mint_amount = 1_000_000;
+			assert_noop!(
+				Balances::mint_tokens_to_sudo(RuntimeOrigin::signed(non_root), sudo_account, mint_amount, false),
+				DispatchError::BadOrigin
+			);
+		});
+}
+
+#[test]
+fn mint_tokens_incremental_up_to_cap() {
+	ExtBuilder::default()
+		.existential_deposit(1)
+		.monied(true)
+		.build_and_execute_with(|| {
+			// Use account ID 1 as the sudo account
+			let sudo_account: u64 = 1;
+			
+			// Mint tokens incrementally for investors up to the cap
+			let mint_amount = 10_000_000; // 10M each time
+			
+			// First mint
+			assert_ok!(Balances::mint_tokens_to_sudo(RawOrigin::Root.into(), sudo_account, mint_amount, false));
+			let (investor_minted, _) = Balances::minted_tokens();
+			assert_eq!(investor_minted, mint_amount);
+			
+			// Second mint
+			assert_ok!(Balances::mint_tokens_to_sudo(RawOrigin::Root.into(), sudo_account, mint_amount, false));
+			let (investor_minted, _) = Balances::minted_tokens();
+			assert_eq!(investor_minted, mint_amount * 2);
+			
+			// Third mint should fail (10M + 10M + 10M > 20M)
+			assert_noop!(
+				Balances::mint_tokens_to_sudo(RawOrigin::Root.into(), sudo_account, mint_amount, false),
+				Error::<Test>::MintCapExceeded
+			);
+			
+			// But we can still mint up to the cap (20M - 20M = 0)
+			assert_noop!(
+				Balances::mint_tokens_to_sudo(RawOrigin::Root.into(), sudo_account, 1, false),
+				Error::<Test>::MintCapExceeded
+			);
+		});
+}
+
+#[test]
+fn mint_tokens_separate_caps() {
+	ExtBuilder::default()
+		.existential_deposit(1)
+		.monied(true)
+		.build_and_execute_with(|| {
+			// Use account ID 1 as the sudo account
+			let sudo_account: u64 = 1;
+			
+			// Define caps
+			const MAX_INVESTOR_TOKENS: u64 = 20_000_000;
+			const MAX_LIQUIDITY_TOKENS: u64 = 20_000_000;
+			
+			// Mint full amount for investors
+			assert_ok!(Balances::mint_tokens_to_sudo(RawOrigin::Root.into(), sudo_account, MAX_INVESTOR_TOKENS, false));
+			
+			// Verify investors cap is reached
+			let (investor_minted, _) = Balances::minted_tokens();
+			assert_eq!(investor_minted, MAX_INVESTOR_TOKENS);
+			
+			// Cannot mint more for investors
+			assert_noop!(
+				Balances::mint_tokens_to_sudo(RawOrigin::Root.into(), sudo_account, 1, false),
+				Error::<Test>::MintCapExceeded
+			);
+			
+			// But can still mint for liquidity
+			assert_ok!(Balances::mint_tokens_to_sudo(RawOrigin::Root.into(), sudo_account, MAX_LIQUIDITY_TOKENS, true));
+			
+			// Verify both caps are now reached
+			let (investor_minted, liquidity_minted) = Balances::minted_tokens();
+			assert_eq!(investor_minted, MAX_INVESTOR_TOKENS);
+			assert_eq!(liquidity_minted, MAX_LIQUIDITY_TOKENS);
+			
+			// Cannot mint more for liquidity
+			assert_noop!(
+				Balances::mint_tokens_to_sudo(RawOrigin::Root.into(), sudo_account, 1, true),
+				Error::<Test>::MintCapExceeded
+			);
+			
+			// Get initial issuance
+			let initial_issuance = Balances::total_issuance() - MAX_INVESTOR_TOKENS - MAX_LIQUIDITY_TOKENS;
+			
+			// Total issuance should reflect both minted amounts
+			assert_eq!(Balances::total_issuance(), initial_issuance + MAX_INVESTOR_TOKENS + MAX_LIQUIDITY_TOKENS);
+		});
+}

--- a/frame/balances/src/tests/mod.rs
+++ b/frame/balances/src/tests/mod.rs
@@ -48,6 +48,7 @@ mod dispatchable_tests;
 mod fungible_conformance_tests;
 mod fungible_tests;
 mod reentrancy_tests;
+mod minting_tests;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 


### PR DESCRIPTION
- Added `mint_tokens_to_sudo` function with 40M token cap
- Implemented separate 20M caps for investors and liquidity pools
- Function accepts a target account parameter for flexibility
- Added storage for tracking minted token amounts by category
- Integrated with existing Total Issuance mechanisms
- Added comprehensive tests for minting functionality
- Enforced root-only access for security
- Emits appropriate events for minting and total issuance updates